### PR TITLE
Refactor-relay-simplify-tools-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,27 +41,32 @@ After linking, running via `npx` will use your local relay version.
 ## Key Features
 
 ### Code Editing Support
+
 - Review proposed code changes from an LLM through diffs, allowing you to accept, reject, or provide feedback.
 - Real-time diagnostic messages (e.g., type errors) sent instantly to the LLM for immediate corrections.
 
 ![Code editing diff](https://storage.googleapis.com/zenn-user-upload/778b7e9ad8c4-20250407.gif)
 
 ### Terminal Operations
+
 - Execute commands within VSCode’s integrated terminal (supports background/foreground execution, and timeout settings).
 
 ### Preview Tools
+
 - Preview URLs directly within VSCode’s built-in browser (e.g., automatically opens browser preview after starting a Vite server).
 
 ![Preview tool](https://storage.googleapis.com/zenn-user-upload/8968c9ad3920-20250407.gif)
 
 ### Multi-instance Switching
+
 - Easily switch the MCP server between multiple open VSCode windows.(Just by clicking the status bar item)
 
 ![Instance switching](https://storage.googleapis.com/zenn-user-upload/0a2bc2bee634-20250407.gif)
 
-### Relay Functionality (Experimental)
-- Relay and expose built-in MCP servers introduced in VSCode 1.99 externally.
-- Allows external access to tools provided by other MCP extensions, such as GitHub Copilot.
+### Relay Functionality
+
+- Returns only the built-in tools defined in the relay's `initial_tools.ts`.
+- Proxies tool execution to the VSCode MCP extension at `--server-url`.
 
 ## Available Built-in Tools
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -24,23 +24,9 @@ class MCPRelay {
       },
     });
 
-    this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request): Promise<ListToolsResult> => {
-      try {
-        const response = await this.requestWithRetry(this.serverUrl, JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'tools/list',
-          params: request.params,
-          id: Math.floor(Math.random() * 1000000),
-        } as JSONRPCRequest));
-        const parsedResponse = response as JSONRPCResponse;
-        const tools = parsedResponse.result.tools as any[];
-        const filteredTools = this.filterTools(tools);
-        return { tools: filteredTools };
-      } catch (err) {
-        console.error(`Failed to fetch tools list: ${(err as Error).message}`);
-        const fallback = this.filterTools(initialTools);
-        return { tools: fallback as any[] };
-      }
+    this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (_request): Promise<ListToolsResult> => {
+      const tools = this.filterTools(initialTools);
+      return { tools: tools as any[] };
     });
 
     this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {


### PR DESCRIPTION
- Remove complex request handling for tools listing.
- Directly return filtered initial tools instead.