### PR TITLE
Fix/confirmation-ui-inputbox-cursor

### DIFF
--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 - 2025-08-22
+
+- fix(confirmation_ui): set cursor position in input box confirmation
+
 ## 0.1.1 - 2025-08-22
 
 - docs(extension): improve documentation

--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vsc-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vsc-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.3",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "VSC-MCP Server",
   "description": "A VSCode extension that exposes your IDE as an MCP server — compensating for missing capabilities required by AI agents and enabling advanced control.",
   "publisher": "ivan-mezentsev",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "commonjs",
   "icon": "icon.png",
   "categories": [

--- a/packages/extension/src/utils/confirmation_ui.ts
+++ b/packages/extension/src/utils/confirmation_ui.ts
@@ -31,6 +31,8 @@ export class ConfirmationUI {
     const inputBox = vscode.window.createInputBox();
     inputBox.title = message;
     inputBox.value = initialCommand;
+    // Place cursor at the start without selection
+    inputBox.valueSelection = [0, 0];
     inputBox.ignoreFocusOut = true;
 
     const approveButton: vscode.QuickInputButton = {


### PR DESCRIPTION
- Ensure the cursor is placed at the start of the input box without selection.