### PR TITLE
Feat/add-save-report

### DIFF
--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 0.3.2 - 2025-08-26
+
+- Introduced a new "Save" button in the ask report webview.
+
 ## 0.3.1 - 2025-08-25
 
-- Remove express dependency
+- Remove express dependency.
 
 ## 0.3.0 - 2025-08-24
 

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "VSC-MCP Server",
   "description": "A VSCode extension that exposes your IDE as an MCP server — compensating for missing capabilities required by AI agents and enabling advanced control.",
   "publisher": "ivan-mezentsev",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "commonjs",
   "icon": "icon.png",
   "categories": [

--- a/packages/extension/src/test/tools/ask_report.test.ts
+++ b/packages/extension/src/test/tools/ask_report.test.ts
@@ -194,4 +194,24 @@ suite('ask_report tool', () => {
         const r2 = await p2;
         assert.strictEqual(r2.value, 'B');
     });
+
+    test('9.9 save opens untitled markdown and shows it', async () => {
+        const fake = createFakePanel();
+        sandbox.stub(vscode.window, 'createWebviewPanel').returns(fake.panel as any);
+        sandbox.stub(vscode.extensions, 'getExtension').returns({ extensionUri: vscode.Uri.file('/') } as any);
+        sandbox.stub(vscode.workspace, 'getConfiguration').returns({ get: () => 0 } as any);
+
+        const openStub = sandbox.stub(vscode.workspace, 'openTextDocument').resolves({} as any);
+        const showStub = sandbox.stub(vscode.window, 'showTextDocument').resolves({} as any);
+
+        const p = askReport({ markdown: 'MD' });
+        fake.send({ type: 'save', text: 'MD' });
+        fake.send({ type: 'cancel' });
+        await p;
+
+        sinon.assert.calledOnce(openStub);
+        const arg = openStub.getCall(0).args[0];
+        assert.deepStrictEqual(arg, { language: 'markdown', content: 'MD' });
+        sinon.assert.calledOnce(showStub);
+    });
 });


### PR DESCRIPTION
- Introduced a new "Save" button in the ask report webview.
- Implemented event listener for the save button to handle saving markdown content.
- Added visual feedback for the save button when clicked.
- Updated icon for the save button to match the UI style.