### PR TITLE
Feat/ask_report-enable-markdown-tables

### DIFF
--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1 - 2025-09-16
+
+- feat(ask_report): enable GitHub-flavored markdown support for tables
+
 ## 0.5.0 - 2025-09-16
 
 - Replaced marked.min.js with markdown-deps.js to bundle marked and highlight.js.

--- a/packages/extension/media/ask_report.css
+++ b/packages/extension/media/ask_report.css
@@ -213,3 +213,10 @@ body.vscode-high-contrast .hljs-string,
 body.vscode-high-contrast .hljs-number,
 body.vscode-high-contrast .hljs-variable,
 body.vscode-high-contrast .hljs-title { font-weight: 600; }
+
+/* Tables */
+.markdown table { border-collapse: collapse; width: 100%; margin: 0.75em 0; font-variant-numeric: tabular-nums; }
+.markdown th, .markdown td { border: 1px solid var(--vscode-editorWidget-border); padding: 4px 8px; text-align: left; vertical-align: top; }
+.markdown thead th { background: var(--vscode-editor-inactiveSelectionBackground, rgba(127,127,127,0.15)); }
+.markdown .table-wrapper { overflow-x: auto; }
+.markdown .table-wrapper table { min-width: fit-content; }

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "VSC-MCP Server",
   "description": "A VSCode extension that exposes your IDE as an MCP server — compensating for missing capabilities required by AI agents and enabling advanced control.",
   "publisher": "ivan-mezentsev",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "commonjs",
   "icon": "icon.png",
   "categories": [

--- a/packages/extension/src/tools/ask_report.ts
+++ b/packages/extension/src/tools/ask_report.ts
@@ -414,6 +414,15 @@ export async function askReport(opts: AskReportOptions): Promise<AskUserResult> 
                 try {
                     // Render markdown using marked with HTML disabled for safety
                     if (window.marked) {
+                        // Ensure GitHub-flavored markdown (tables, etc.) is enabled.
+                        try {
+                            if (typeof window.marked.setOptions === 'function') {
+                                window.marked.setOptions({ gfm: true });
+                            } else {
+                                // Fallback: some versions use .use() pattern
+                                window.marked.use({ gfm: true });
+                            }
+                        } catch {}
                         window.marked.use({ mangle: false, headerIds: false });
                         const html = window.marked.parse(initData.markdown || '', { async: false });
                         el.markdown.innerHTML = html;


### PR DESCRIPTION
- Add support for GitHub-flavored markdown in the ask_report tool.
- Update the markdown rendering options to include table support.
- Ensure compatibility with different versions of the marked library.