### PR TITLE
Feat/new-status-bar

### DIFF
--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3 - 2025-09-18
+
+- feat(status-bar): enhance tooltip with discovery snapshot details
+
 ## 0.5.2 - 2025-09-16
 
 - feat(ask_report): add support for Mermaid diagrams in markdown

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "VSC-MCP Server",
   "description": "A VSCode extension that exposes your IDE as an MCP server — compensating for missing capabilities required by AI agents and enabling advanced control.",
   "publisher": "ivan-mezentsev",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "commonjs",
   "icon": "icon.png",
   "categories": [


### PR DESCRIPTION
- Add functionality to display a markdown table in the status bar tooltip
  showing discovery instances (Port | TTL | Workspace).
- Implement periodic refresh of the tooltip to ensure live TTL countdown.
- Introduce event listeners for discovery updates to refresh the status bar
  when new instances are discovered.